### PR TITLE
Allow {{address}} in Dapp urls

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -26,7 +26,7 @@ export default Joi.object({
         categoryId: Joi.string().required(),
         description: Joi.string().required(),
         logoUrl: Joi.string().uri().required(),
-        url: Joi.string().uri().required(),
+        url: Joi.string().replace('{{address}}', '').uri().required(),
       }),
     )
     .unique((application0, application1) => {


### PR DESCRIPTION
We allow setting an `{{address}}` in the URL but the validation was failing when one was added