### PR TITLE
Made schema validatation more strict

### DIFF
--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -210,6 +210,23 @@ describe('invalid categories entries', () => {
     )
   })
 
+  it('errors on missing localized name', () => {
+    const testDappObject = {
+      categories: [
+        {
+          id: '1',
+          name: 'categories.exchanges-something', // This key is missing in locales/base.json
+          backgroundColor: '#DEF8EA',
+          fontColor: '#1AB775',
+        },
+      ],
+      applications: [],
+    }
+    expect(`${schema.validate(testDappObject).error}`).toBe(
+      "ValidationError: \"categories[0].name\" failed custom validation because Missing localization key 'categories.exchanges-something' in 'locales/base.json'",
+    )
+  })
+
   it('errors on duplicate category entry', () => {
     const testDappObject = {
       categories: [
@@ -488,11 +505,11 @@ describe('invalid applications entries', () => {
       ],
     }
     expect(`${schema.validate(testDappObject).error}`).toBe(
-      'ValidationError: "applications[0].logoUrl" must be a valid uri',
+      'ValidationError: "applications[0].logoUrl" with value "javascript:alert("Hello World")" fails to match the required pattern: /^https:\\/\\/raw.githubusercontent.com\\/valora-inc\\/app-list\\/main\\/assets\\/[^/]+\\.png$/',
     )
   })
 
-  it('errors on invalid logoUrl uri', () => {
+  it('errors on invalid url uri', () => {
     const testDappObject = {
       categories: [category],
       applications: [
@@ -508,7 +525,47 @@ describe('invalid applications entries', () => {
       ],
     }
     expect(`${schema.validate(testDappObject).error}`).toBe(
-      'ValidationError: "applications[0].url" must be a valid uri',
+      'ValidationError: "applications[0].url" must be a valid uri with a scheme matching the celo|https pattern',
+    )
+  })
+
+  it('errors on missing localized description', () => {
+    const testDappObject = {
+      categories: [category],
+      applications: [
+        {
+          name: 'Ubeswap',
+          id: '1',
+          categoryId: '1',
+          description: 'dapps.ubeswap-something', // this key doesn't exist in locales/base.json
+          logoUrl:
+            'https://raw.githubusercontent.com/valora-inc/app-list/main/assets/ubeswap.png',
+          url: 'https://app.ubeswap.org/',
+        },
+      ],
+    }
+    expect(`${schema.validate(testDappObject).error}`).toBe(
+      "ValidationError: \"applications[0].description\" failed custom validation because Missing localization key 'dapps.ubeswap-something' in 'locales/base.json'",
+    )
+  })
+
+  it('errors on missing asset in the repo', () => {
+    const testDappObject = {
+      categories: [category],
+      applications: [
+        {
+          name: 'Ubeswap',
+          id: '1',
+          categoryId: '1',
+          description: 'dapps.ubeswap',
+          logoUrl:
+            'https://raw.githubusercontent.com/valora-inc/app-list/main/assets/ubeswap-something.png', // This asset doesn't exist in the repo
+          url: 'https://app.ubeswap.org/',
+        },
+      ],
+    }
+    expect(`${schema.validate(testDappObject).error}`).toBe(
+      'ValidationError: "applications[0].logoUrl" failed custom validation because Missing asset at \'../assets/ubeswap-something.png\'',
     )
   })
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,13 +1,57 @@
-import Joi from 'joi'
+import Joi, { CustomValidator } from 'joi'
+import base from '../locales/base.json'
+import i18next from 'i18next'
+import fs from 'fs'
+import { URL } from 'url'
+import path from 'path'
 
 const colorCodePattern = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+
+i18next
+  .init({
+    resources: {
+      base: {
+        translation: base,
+      },
+    },
+    lng: 'base',
+  })
+  .catch((reason: any) =>
+    console.error('Config', 'Failed to init i18n', reason),
+  )
+
+const checkMatchingLocalization: CustomValidator = (value) => {
+  const localizedValue = i18next.t(value)
+  if (!localizedValue || localizedValue === value) {
+    throw new Error(
+      `Missing localization key '${value}' in 'locales/base.json'`,
+    )
+  }
+
+  return value
+}
+
+const checkMatchingAsset: CustomValidator = (value) => {
+  const url = new URL(value)
+  const filename = path.basename(url.pathname)
+  const assetPath = path.join(__dirname, '../assets', filename)
+  if (!fs.existsSync(assetPath)) {
+    throw new Error(`Missing asset at '${path.relative(__dirname, assetPath)}'`)
+  }
+
+  return value
+}
 
 export const schema = Joi.object({
   categories: Joi.array()
     .items(
       Joi.object({
         id: Joi.string().required(),
-        name: Joi.string().required(),
+        name: Joi.string()
+          // Matches categories.something
+          .pattern(/^categories\.([a-zA-Z0-9\-]+)$/)
+          .custom(checkMatchingLocalization, 'has a matching localization')
+          .required(),
         backgroundColor: Joi.string().pattern(colorCodePattern).required(),
         fontColor: Joi.string().pattern(colorCodePattern).required(),
       }),
@@ -26,9 +70,25 @@ export const schema = Joi.object({
         id: Joi.string().required(),
         name: Joi.string().required(),
         categoryId: Joi.string().required(),
-        description: Joi.string().required(),
-        logoUrl: Joi.string().uri().required(),
-        url: Joi.string().replace('{{address}}', '').uri().required(),
+        description: Joi.string()
+          // Matches dapps.something
+          .pattern(/^dapps\.([a-zA-Z0-9\-]+)$/)
+          .custom(checkMatchingLocalization, 'has a matching localization')
+          .required(),
+        logoUrl: Joi.string()
+          // For now only allow assets within this repo
+          .pattern(
+            /^https:\/\/raw.githubusercontent.com\/valora-inc\/app-list\/main\/assets\/[^/]+\.png$/,
+          )
+          .uri()
+          .custom(checkMatchingAsset, 'has a matching asset')
+          .required(),
+        url: Joi.string()
+          .replace('{{address}}', '')
+          .uri({
+            scheme: ['celo', 'https'],
+          })
+          .required(),
       }),
     )
     .min(1)


### PR DESCRIPTION
I saw some incorrect submissions still passing the checks.

The schema is now more strict:
- Prevent missing localization for dapp description and category name
- Prevent missing asset (for now only from this repo)
- Ensure `https` or `celo` links
