### PR TITLE
chore: remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm' # For dependabot npm is synonymous to yarn
-    directory: '/'
-    schedule:
-      interval: 'daily'


### PR DESCRIPTION
We're using Renovate instead.