### PR TITLE
fix: add lend-borrow-earn key an en translation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,13 +1,16 @@
 {
   "categories": {
     "exchanges": "Swap",
-    "lend": "Lend, Borrow & Earn",
+    "lend-borrow-earn": "Lend, Borrow & Earn",
     "spend": "Spend",
     "finance-tools": "Financial Tools",
     "social-impact": "Impact",
     "social": "Social",
     "nfts": "NFTs",
-    "games": "Games"
+    "games": "Games",
+    "lend": "Lend",
+    "borrow": "Borrow",
+    "earn": "Earn"
   },
   "dapps": {
     "staked-celo": "Stake CELO and earn rewards while keeping your assets liquid",


### PR DESCRIPTION
#### Description

It looks like in PR #377 en was omitted from the translation list. This PR will fix this so that the `Lend, Borrow, & Earn` category is excluded in the v2 dapps list as intended in #369.