### PR TITLE
Chore: add swftpro to ignore list

### DIFF
--- a/cypress/e2e/dapps.cy.ts
+++ b/cypress/e2e/dapps.cy.ts
@@ -4,7 +4,7 @@ import data from '../../src/valora-dapp-list.json'
 
 const ignoreList = [
   'gooddollar', // Blocks Microsoft services via Cloudflare
-  'swftpro', // Blocks Microsoft services via Cloudflare  
+  'swftpro', // Blocks Microsoft services via Cloudflare
 ]
 
 describe('Dapp Up Check', () => {


### PR DESCRIPTION
### Description

Dapp Up Checks are failing for www.allchainbridge.com [likely due to Cloudflare](https://github.com/valora-inc/dapp-list/actions/runs/4928506059). As such I am adding them to the ignore list for the Dapp Up check to avoid false positives.