### PR TITLE
chore: delist Ariswap

### DIFF
--- a/src/valora-dapp-list.json
+++ b/src/valora-dapp-list.json
@@ -306,15 +306,6 @@
       "listOnIos": true
     },
     {
-      "name": "Ariswap",
-      "id": "ariswap",
-      "categoryId": "nfts",
-      "categories": ["nfts"],
-      "url": "https://ariswap.co/",
-      "listOnAndroid": true,
-      "listOnIos": false
-    },
-    {
       "name": "Ipermatch",
       "id": "ipermatch",
       "categoryId": "games",


### PR DESCRIPTION
https://ariswap.co/ has been down since June 24 as of this writing. We will remove it from the dapps list and add back if and when the issue is fixed.