### PR TITLE
test(e2e): add stake-dao to ignore list

### DIFF
--- a/cypress/e2e/dapps.cy.ts
+++ b/cypress/e2e/dapps.cy.ts
@@ -7,6 +7,7 @@ const ignoreList = [
   'swftpro', // Blocks Microsoft services via Cloudflare
   'llamaswap', // Fails with 403 on first load
   'layer3', // Blocks Microsoft services via Cloudflare
+  'stake-dao', // Fails with 403 on load
 ]
 
 describe('Dapp Up Check', () => {


### PR DESCRIPTION
### Description

Stake Dao was returning 403 on the first load, failing our Cypress e2e tests and alerting the [dapps-list channel](https://valora-app.slack.com/archives/C02UAE4MGUF/p1733634069070899). /valora-app.slack.com/archives/C02UAE4MGUF/p1733634069070899) channel. This PR adds Stake Dao to the ignore list.
