### PR TITLE
test(e2e): add kiwi to ignore list

### DIFF
--- a/cypress/e2e/dapps.cy.ts
+++ b/cypress/e2e/dapps.cy.ts
@@ -8,6 +8,7 @@ const ignoreList = [
   'llamaswap', // Fails with 403 on first load
   'layer3', // Blocks Microsoft services via Cloudflare
   'stake-dao', // Fails with 403 on load
+  'kiwi', // Blocks Microsoft services via Cloudflare
 ]
 
 describe('Dapp Up Check', () => {


### PR DESCRIPTION
### Description

Adds Kiwi dapp to e2e ignore list due to Cloudflare blocking uptime-check.
