### PR TITLE
fix: use live curve url

### DIFF
--- a/src/valora-dapp-list.json
+++ b/src/valora-dapp-list.json
@@ -166,7 +166,7 @@
       "id": "curve",
       "categoryId": "exchanges",
       "categories": ["exchanges", "earn"],
-      "url": "https://curve.fi/#/celo/swap",
+      "url": "https://curve.finance/#/celo/swap",
       "listOnAndroid": true,
       "listOnIos": true
     },


### PR DESCRIPTION
### Description

Use new Curve URL: https://curve.finance/#/celo/swap.
