### PR TITLE
chore(renovate): block major updates for image-size due to CI issues

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,3 +1,10 @@
 {
   extends: ['github>valora-inc/renovate-config:default.json5'],
+  packageRules: [
+    {
+      // Disable updates for image-size as 2.x breaks CI
+      matchPackageNames: ['image-size'],
+      allowedVersions: '<2',
+    },
+  ],
 }


### PR DESCRIPTION
### Description

Image-size major upgrades break CI. This is to get renovate to ignore these and to allow automated updates to continue.