### PR TITLE
chore(deps): move joi and i18next to dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "e2e:run": "cypress run --headless"
   },
   "prettier": "@valora/prettier-config",
+  "dependencies": {
+    "joi": "^17.13.3",
+    "i18next": "~24.1.0"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^17.0.45",
@@ -31,10 +35,8 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-native": "^4.1.0",
-    "i18next": "~24.1.0",
     "image-size": "^1.1.1",
     "jest": "^29.7.0",
-    "joi": "^17.13.3",
     "prettier": "^3.5.3",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
### Description

Moves dependencies from devDependencies so that Renovate PR is no longer stuck: https://github.com/valora-inc/dapp-list/pull/702.
