### PR TITLE
test(e2e): add hedgey to exclusion list for dapp up check

### DIFF
--- a/cypress/e2e/dapps.cy.ts
+++ b/cypress/e2e/dapps.cy.ts
@@ -10,6 +10,7 @@ const ignoreList = [
   'stake-dao', // Fails with 403 on load
   'kiwi', // Blocks Microsoft services via Cloudflare
   'sarafu', // Blocks Microsoft services via Vercel
+  'hedgey', // Blocks Microsoft services via Vercel
 ]
 
 describe('Dapp Up Check', () => {


### PR DESCRIPTION
### Description

Adds Hedgey to the exclusion list for the dapp up check: [failed action](https://github.com/valora-inc/dapp-list/actions/runs/17047331684/job/48326417635).