### PR TITLE
ci(e2e): add plastiks to exclusion list

### DIFF
--- a/cypress/e2e/dapps.cy.ts
+++ b/cypress/e2e/dapps.cy.ts
@@ -13,6 +13,7 @@ const ignoreList = [
   'hedgey', // Blocks Microsoft services via Vercel
   'celosphere', // Fails without vpn connection
   'allbridgecore', // Fails with 403 on load
+  'plastiks', // Blocks Microsoft services via Cloudflare
 ]
 
 describe('Dapp Up Check', () => {


### PR DESCRIPTION
## Description
Adds `plastiks` to the Cypress e2e ignore list (blocks Microsoft services via Cloudflare, causing the up-check to fail)