### PR TITLE
test(e2e): set root dir

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "include": ["."],
   "compilerOptions": {
-    "sourceMap": false
+    "sourceMap": false,
+    "rootDir": "."
   }
 }


### PR DESCRIPTION
## Summary
Fixes a Webpack/ts-loader compilation error (`TS6059: File ... is not under 'rootDir'`) that started failing `yarn e2e:run` after the Cypress 15 upgrade. Cypress 15's stricter ts-loader now enforces the `rootDir: "src"` inherited from the root, `tsconfig.json`, which excluded `cypress/e2e/*.cy.ts`. Tracked upstream in cypress-io/cypress#33648.

## Changes
- **Override `rootDir` in `cypress/tsconfig.json`** — set to `"."` so Cypress test files are considered under their own root instead of the app's `src/`.